### PR TITLE
tweak styles for small screens and scrollbars

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,14 +87,15 @@
       }
       #toplevel-side{
       background-color: #fff;
-      position:relative;
-      width:45%;
+      position: absolute;
+      right: 0;
+      width: 50%;
       height: 100%;
-      padding-top: 20px;
+      padding: 20px;
+      padding-left: 30px;
       overflow: auto;
       text-align:justify;
       float:left;
-      margin-left:30px;
       color: rgb(80, 80, 80);
       font-family: Helvetica Neue, Open Sans, sans-serif;
       }


### PR DESCRIPTION
This fixes a couple small issues with the main page.

Before (notice the scrollbar is weirdly in from the side of the screen, and the right disappears at small sizes):
<img width="526" alt="screen shot 2016-06-23 at 9 23 29 pm" src="https://cloud.githubusercontent.com/assets/4370652/16327876/fc770500-3988-11e6-9e40-5be4afe96400.png">
<img width="497" alt="screen shot 2016-06-23 at 9 23 18 pm" src="https://cloud.githubusercontent.com/assets/4370652/16327877/fc77d962-3988-11e6-8a0a-b3fbc97329e9.png">

After:
<img width="421" alt="screen shot 2016-06-23 at 9 22 50 pm" src="https://cloud.githubusercontent.com/assets/4370652/16327882/034aea18-3989-11e6-968b-a4bc3b16311d.png">


